### PR TITLE
Add HalLoc paper to the MLLM Hallucination List

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2402.00253)
 
 
-### Hallucination Evaluation & Analysis 
+### Hallucination Evaluation & Analysis
++ **HalLoc** [HalLoc: Token-level Localization of Hallucinations for Vision Language Models] (June. 12, 2025, CVPR 2025)
+  [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2506.10286)
+
 + **UNSCENE** [MASH-VLM:Mitigating Action-Scene Hallucination in Video-LLMs through Disentangled Spatial-Temporal Representations](https://arxiv.org/abs/2503.15871) (Mar. 20, 2025, CVPR 2025)
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2503.15871)
 


### PR DESCRIPTION
Hello,

Thank you for maintaining this helpful repository!  
We would like to add our CVPR 2025 paper *HalLoc: Token-level Localization of Hallucinations for Vision-Language Models*, which tackles token-level hallucination detection in vision-language models
**_HalLoc: Token-level Localization of Hallucinations for Vision Language Models_**
Paper: https://arxiv.org/abs/2506.10286
Dataset: https://huggingface.co/datasets/uunicee/HalLoc
Highlights: 155K+ samples across VQA, Captioning, and Instruction tasks, with fine-grained annotations for four hallucination types (object, attribute, relationship, scene)

Thanks for your consideration!

Best,  
EunKyu