### PR TITLE
Add Attend-to-Evidence paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 
 
 ### Hallucination Mitigation 
++ **Attend-to-Evidence** [Attend to Evidence: Evidence-Anchored Spatial Attention Supervision for Multimodal RLVR](https://arxiv.org/abs/2605.30912) (May. 29, 2026)
+  [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2605.30912)
+
 + **SENTINEL** [Mitigating Object Hallucinations via Sentence-Level Early Intervention](https://arxiv.org/abs/2507.12455) (Jul. 21, 2025, ICCV 2025)
   [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2507.12455)
   [![Star](https://img.shields.io/github/stars/fatemehpesaran310/lpoi.svg?style=social&label=Star)](https://github.com/pspdada/SENTINEL)


### PR DESCRIPTION
Hi! Thanks for putting this list together. Could I add Attend-to-Evidence to the Hallucination Mitigation section? Attend-to-Evidence introduces evidence-anchored spatial attention supervision for multimodal RLVR, explicitly aligning visual attention with annotated evidence regions to mitigate hallucination in vision-language models (May 2026).

Paper: https://arxiv.org/abs/2605.30912

Thanks!
